### PR TITLE
Add Project Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,42 @@
+---
+name: Bug
+about: Plantilla que describe un nuevo error
+---
+
+## Título del bug
+
+### Descripción
+
+Este bloque de texto deberá ser reemplazado con la descripción del error presentado. Es importante tomar capturas de pantalla que puedan resultar útiles.
+
+### Pasos para reproducir
+
+1. Paso uno detallado
+2. Paso dos detallado
+
+### Comportamiento esperado
+
+Cuando < acción >, la aplicación debe de < comportamiento esperado >
+
+### Comportamiento actual
+
+Cuando < acción >, la aplicación esta < comportamiento actual >
+
+### Context
+
+| Navegador | Version | OS |
+|----------|:-------------:|------:|
+| firefox | 34 | Windows |
+
+===
+
+| Dispositivo | OS | Version |
+|----------|:-------------:|------:|
+| Pixel 2 | Android | 9.0 |
+
+### Archivos que pudieran verse afectados
+
+- [app/models/user.rb](/)
+- [app/views/users/profile.html.erb](/)
+
+### Capturas de pantalla

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,37 @@
+---
+name: Historia de usuario
+about: Plantilla que describe una nueva funcionalidad
+---
+
+## Título de la historia de usuario
+
+Como < tipo de usuario > puedo < descripción de la funcionalidad > para < objetivo >
+
+### Puntos de complejidad
+
+< # de puntos de complejidad >
+
+### Conversación
+
+Este bloque de texto debe ser utilizado para dar un poco más de contexto para la funcionalidad. Asi mismo puedes
+mencionar la existencia o uso de un plugin o solución de algún tercero que se vaya a implementar o ya este ejecutandose actualmente.
+
+### Criterios de aceptación
+
+- [ ] Criterio de aceptación 1
+- [ ] Criterio de aceptación 2
+- [ ] Criterio de aceptación 3
+
+### Definition of Done
+
+- [ ] ¿Las pruebas están pasando?
+- [ ] ¿Recibiste revisión de código?
+
+### Definition of Ready
+
+- [ ] Elemento 1
+- [ ] Elemento 2
+
+## Issues relacionados, Pull Requests y/o recursos
+
+Un listado de referencias dentro del código que puedan ser valiosas para otro desarrollador, alguna liga, plugin, referencia de diseño. 

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,22 @@
+---
+name: Task
+about: Plantilla que describe tareas técnicas, tales como optimizaciones, refactor, tareas de la base de datos
+---
+
+## Título de la tarea
+
+### Descripción
+
+Este texto deberá ser reemplazado por una descripción completa de la tarea. Es importante ser explícito, tal como si ya se estuviera creando el código necesario. Si lo consideras apropiado, trata de responder la siguiente pregunta: "¿cúal es el propósito de la tarea?"
+
+Please replace this text with a complete description of the TASK. You should be as explicit and detailed as if you were building the task while describing it. If appropriate, use the description to answer the question: "what is the purpose of the task?"
+
+### Listado de tareas
+
+- [ ] Tarea 1
+- [ ] Tarea 2
+- [ ] Tarea 3
+
+### Definition of Done
+
+- [ ] ¿Las pruebas están pasando?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+### What does this PR do?
+
+*
+
+#### Merge Checklist:
+
+- [ ] The branch is up-to-date (i.e. rebased) with the base branch
+- [ ] Are the tests passing?
+- [ ] Is GPA high enough?


### PR DESCRIPTION
Add PR and ISSUE templates in order to make it easier for the developers to stick with the established standards.

Each time a user tries to open an issue or open a PR, the established template will be the default. 